### PR TITLE
feat(config): always remove config

### DIFF
--- a/cmd.ps1
+++ b/cmd.ps1
@@ -8,6 +8,7 @@ if ($env:GITHUBREPO_OR_ORG.IndexOf('/') -gt 0) {
 $removalToken = ($(Invoke-WebRequest -UseBasicParsing -Uri "https://api.github.com/$tokenLevel/$env:GITHUBREPO_OR_ORG/actions/runners/remove-token" -Headers $headers -Method POST).Content | ConvertFrom-Json).token;
 $registrationToken = ($(Invoke-WebRequest -UseBasicParsing -Uri "https://api.github.com/$tokenLevel/$env:GITHUBREPO_OR_ORG/actions/runners/registration-token" -Headers $headers -Method POST).Content | ConvertFrom-Json).token;
 
+.\config.cmd remove --url "https://github.com/$env:GITHUBREPO_OR_ORG" --token "$removalToken" --name $env:GITHUBRUNNERNAME --unattended
 .\config.cmd configure --url "https://github.com/$env:GITHUBREPO_OR_ORG" --token "$registrationToken" --name $env:GITHUBRUNNERNAME --unattended --replace ;
 Start-Process -FilePath ".\run.cmd"
 


### PR DESCRIPTION
This allows that a stopped container can be started again. Until now, you need to remove and recreate it because you can't configure an already configured runner.